### PR TITLE
TUI geliştirmesi ve yeni flag

### DIFF
--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -3,8 +3,8 @@ package flags
 import (
 	"runtime"
 
-	"github.com/spf13/cobra"
 	"github.com/axrona/anitr-cli/internal/update"
+	"github.com/spf13/cobra"
 )
 
 type Flags struct {
@@ -12,6 +12,7 @@ type Flags struct {
 	PrintVersion bool
 	RofiMode     bool
 	RofiFlags    string
+	QuickResume  bool
 }
 
 func NewFlagsCmd() (*cobra.Command, *Flags) {
@@ -30,6 +31,9 @@ func NewFlagsCmd() (*cobra.Command, *Flags) {
 
 	cmd.PersistentFlags().BoolVar(&f.DisableRPC, "disable-rpc", false,
 		"Discord Rich Presence desteğini devre dışı bırakır.")
+
+	cmd.PersistentFlags().BoolVar(&f.QuickResume, "go", false,
+		"Son izlenen anime bölümünü açar.")
 
 	cmd.SetVersionTemplate(update.Version())
 	cmd.Version = update.Version()

--- a/internal/models.go
+++ b/internal/models.go
@@ -19,10 +19,11 @@ type Config struct {
 
 // UiParams, UI (kullanıcı arayüzü) ile ilgili parametreleri temsil eder.
 type UiParams struct {
-	Mode      string    // Arayüz modu: "rofi" veya "tui"
-	List      *[]string // Liste halinde kullanıcıya gösterilecek seçenekler
-	Label     string    // UI öğesi için başlık/etiket
-	RofiFlags *string   // Rofi'ye özel ek parametreler (varsa)
+	Mode               string    // Arayüz modu: "rofi" veya "tui"
+	List               *[]string // Liste halinde kullanıcıya gösterilecek seçenekler
+	Label              string    // UI öğesi için başlık/etiket
+	RofiFlags          *string   // Rofi'ye özel ek parametreler (varsa)
+	SkipSeasonSeparators bool    // Sezon ayırıcılarını atla (geçmiş menüsü için)
 }
 
 // RPCParams, Discord Rich Presence için gönderilecek bilgileri içerir.

--- a/internal/models.go
+++ b/internal/models.go
@@ -24,6 +24,7 @@ type UiParams struct {
 	Label              string    // UI öğesi için başlık/etiket
 	RofiFlags          *string   // Rofi'ye özel ek parametreler (varsa)
 	SkipSeasonSeparators bool    // Sezon ayırıcılarını atla (geçmiş menüsü için)
+	SkipAllSeparators    bool    // Tüm separator'ları atla
 }
 
 // RPCParams, Discord Rich Presence için gönderilecek bilgileri içerir.

--- a/internal/ui/tui/tui.go
+++ b/internal/ui/tui/tui.go
@@ -235,6 +235,22 @@ func (m SelectionListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case tea.KeyMsg:
 		switch msg.String() {
+		case "up", "k":
+			// Wrap: en üstteyken yukarı basınca en alta git
+			if m.list.Index() == 0 {
+				items := m.list.Items()
+				if len(items) > 0 {
+					m.list.Select(len(items) - 1)
+					return m, nil
+				}
+			}
+		case "down", "j":
+			// Wrap: en alttayken aşağı basınca en başa git
+			items := m.list.Items()
+			if len(items) > 0 && m.list.Index() == len(items)-1 {
+				m.list.Select(0)
+				return m, nil
+			}
 		case "enter":
 			if i, ok := m.list.SelectedItem().(listItem); ok {
 				m.selected = []string{string(i)}
@@ -321,6 +337,22 @@ func (m MultiSelectionListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case tea.KeyMsg:
 		switch msg.String() {
+		case "up", "k":
+			// Wrap: en üstteyken yukarı basınca en alta git
+			if m.list.Index() == 0 {
+				items := m.list.Items()
+				if len(items) > 0 {
+					m.list.Select(len(items) - 1)
+					return m, nil
+				}
+			}
+		case "down", "j":
+			// Wrap: en alttayken aşağı basınca en başa git
+			items := m.list.Items()
+			if len(items) > 0 && m.list.Index() == len(items)-1 {
+				m.list.Select(0)
+				return m, nil
+			}
 		case "tab", " ":
 			items := m.list.Items()
 			if ci, ok := items[m.list.Index()].(checkboxItem); ok {

--- a/internal/ui/tui/tui.go
+++ b/internal/ui/tui/tui.go
@@ -156,7 +156,7 @@ func (i seasonSeparatorItem) Description() string { return "" }
 func (i seasonSeparatorItem) FilterValue() string { return "" }
 
 // Bölüm listesini sezonlara göre grupla ve ayırıcılar ekle
-func processEpisodesWithSeparators(episodes []string) []string {
+func processEpisodesWithSeparators(episodes []string, skipSeparators bool) []string {
 	if len(episodes) == 0 {
 		return episodes
 	}
@@ -170,8 +170,8 @@ func processEpisodesWithSeparators(episodes []string) []string {
 		}
 	}
 
-	// Eğer hiç bölüm formatında string yoksa, orijinal listeyi döndür
-	if episodeCount == 0 {
+	// Eğer hiç bölüm formatında string yoksa veya ayırıcılar atlanacaksa, orijinal listeyi döndür
+	if episodeCount == 0 || skipSeparators {
 		return episodes
 	}
 
@@ -298,7 +298,7 @@ type SelectionListModel struct {
 
 func NewSelectionListModel(params internal.UiParams) SelectionListModel {
 	// Bölüm listesini işle ve sezon ayırıcıları ekle
-	processedList := processEpisodesWithSeparators(*params.List)
+	processedList := processEpisodesWithSeparators(*params.List, params.SkipSeasonSeparators)
 	items := make([]list.Item, len(processedList))
 
 	for i, v := range processedList {
@@ -471,7 +471,7 @@ type MultiSelectionListModel struct {
 
 func NewMultiSelectionListModel(params internal.UiParams) MultiSelectionListModel {
 	// Bölüm listesini işle ve sezon ayırıcıları ekle
-	processedList := processEpisodesWithSeparators(*params.List)
+	processedList := processEpisodesWithSeparators(*params.List, params.SkipSeasonSeparators)
 	items := make([]list.Item, len(processedList))
 
 	for i, v := range processedList {

--- a/main.go
+++ b/main.go
@@ -640,10 +640,13 @@ func anitrHistory(params internal.UiParams, source string, historyLimit int, log
 	}
 
 	// TUI ile seçim al
-	selectedKey, selErr := showSelection(App{
-		uiMode:    &params.Mode,
-		rofiFlags: params.RofiFlags,
-	}, keys, "Geçmiş")
+	selectedKey, selErr := ui.SelectionList(internal.UiParams{
+		Mode:                 params.Mode,
+		List:                 &keys,
+		Label:                "Geçmiş",
+		RofiFlags:            params.RofiFlags,
+		SkipSeasonSeparators: true,
+	})
 	if selErr != nil {
 		err = selErr
 		return

--- a/main.go
+++ b/main.go
@@ -956,7 +956,7 @@ func playAnimeLoop(
 		}
 
 		// Genel seçenekler
-		watchMenu = append(watchMenu, "Anime ara", "Çık")
+		watchMenu = append(watchMenu, "────────────────────", "Anime ara", "Çık")
 
 		// Menü başlığını hazırla - bölüm bilgisi ile
 		menuTitle := selectedAnimeName
@@ -976,7 +976,6 @@ func playAnimeLoop(
 			Mode:      uiMode,
 			RofiFlags: &rofiFlags,
 		}, err, logger)
-
 
 		switch option {
 

--- a/main.go
+++ b/main.go
@@ -955,8 +955,15 @@ func playAnimeLoop(
 		// Genel seçenekler
 		watchMenu = append(watchMenu, "Anime ara", "Çık")
 
+		// Menü başlığını hazırla - bölüm bilgisi ile
+		menuTitle := selectedAnimeName
+		if !isMovie {
+			currentEpisode := episodeNames[selectedEpisodeIndex]
+			menuTitle = fmt.Sprintf("%s ( %s )", selectedAnimeName, currentEpisode)
+		}
+
 		// Seçim arayüzünü göster
-		option, err := showSelection(App{uiMode: &uiMode, rofiFlags: &rofiFlags}, watchMenu, selectedAnimeName)
+		option, err := showSelection(App{uiMode: &uiMode, rofiFlags: &rofiFlags}, watchMenu, menuTitle)
 
 		if errors.Is(err, tui.ErrGoBack) {
 			return nil, "", err
@@ -966,6 +973,7 @@ func playAnimeLoop(
 			Mode:      uiMode,
 			RofiFlags: &rofiFlags,
 		}, err, logger)
+
 
 		switch option {
 


### PR DESCRIPTION
## 📝 Neler değişti?

Bu PR, TUI deneyimini iyileştiren birkaç önemli özellik içermektedir. Ayrıca, kullanım kolaylığını artıran yeni bir hızlı başlatma özelliği flagi (--go) eklenmiştir.

### ✨ Yeni Özellikler

-   **TUI'de Sezon ve Genel Ayırıcılar**:
    -   Bölüm listelerine, bölümleri sezonlara göre gruplayan görsel ayırıcılar eklendi.(`───── X. Sezon ─────`) şeklinde.
    -   Watch menüde karmaşıklığı azaltmak için ayıraç eklendi.
-   **İyileştirilmiş TUI Navigasyonu**:
    -   Listelerde `yukarı/aşağı` ve `j/k` tuşları ile gezinirken, listenin sonundan başına (veya tersi) atlama (wrap-around) özelliği eklendi.
-   **Hızlı Devam Et Özelliği ve (`--go`) bayrağı**:
    -   Uygulamayı `--go` bayrağı ile başlatarak, en son izlenen anime bölümünü menülerde gezinmeden izleme menüsünü açma özelliği eklendi.
-    **İzleme Menüsü Başlığı**: İzleme menüsünün (watch menu) başlığına, o an seçili olan bölümün adı eklenerek kullanıcının hangi bölümde olduğunu daha net görmesi sağlandı.

## 📌 Sebep?

Bu değişikliklerin temel amacı, `anitr-cli`'nin kullanıcı deneyimini daha akıcı ve sezgisel hale getirmek.

-   **TUI İyileştirmeleri**: Özellikle çok sayıda bölümü olan animelerde, sezon ayırıcıları ve geliştirilmiş navigasyon, kullanıcıların aradıkları bölüme daha hızlı ulaşmasını sağlar. Ayrıca izleme menüsünde eklenen bölüm bilgisi kullanıcı deneyimi açısından önemlidir. 
<img width="323" height="239" alt="image" src="https://github.com/user-attachments/assets/74eb08ba-fe61-4349-8b4a-c1cc72818ef4" />
<img width="393" height="458" alt="image" src="https://github.com/user-attachments/assets/20fccb62-ab2f-4ba1-96e1-85b370c5d55f" />

-   **`--go` Özelliği**: Sık kullanılan "kaldığın yerden devam et" işlevini tek bir komutla erişilebilir kılarak uygulamayı daha pratik hale getirir.